### PR TITLE
PowerUp: Fix splitting source code lines on Windows

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -12,3 +12,4 @@ All contributors that made changes to PowerUp before the "Contributor License Ag
 
 1. Bartosz Adamczewski
 2. Yoh Deadfall
+3. Andrii Rybalko

--- a/src/PowerUp.Watcher/ILWriter.cs
+++ b/src/PowerUp.Watcher/ILWriter.cs
@@ -17,7 +17,7 @@ namespace PowerUp.Watcher
 
         public string ToILString(DecompilationUnit unit)
         {
-            var lines = unit.InputSouceCode.Split(Environment.NewLine);
+            var lines = unit.InputSouceCode.Replace("\r", string.Empty).Split('\n');
 
             StringBuilder builder = new StringBuilder();
             builder.AppendLine();


### PR DESCRIPTION
This PR fixes https://github.com/badamczewski/PowerUp/issues/11.